### PR TITLE
Add option to apply for current user only

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This implementation should work for MSYS2 and MINGW32/64 shells that come with M
    your desired directory to install
    - Or `git clone https://github.com/njzhangyifei/msys2-mingw-shortcut-menus.git`
    when git via ssh is not available
-2. `./install` and follow the instructions
+2. `./install` and follow the instructions. Use `./install --user` for current user only
 3. double-click `install_right_click_menu.reg` file to merge it into your
    windows registry
 4. **(Optional)** If you don't see icons in the context menu, please install `msys2-launcher`

--- a/install
+++ b/install
@@ -59,6 +59,18 @@ if [[ ! $option =~ [yY](es)* ]]; then
     exit 0
 fi
 
+if [ "$1" = '--user' ]; then
+	ROOT_KEY="HKEY_CURRENT_USER"
+	echo -e "${COL_GREEN}"
+	echo -e "Configuration will be stored in user context only ('HKEY_CURRENT_USER')"
+	echo -e "${COL_RESET}"
+else
+	ROOT_KEY="HKEY_LOCAL_MACHINE"
+	echo -e "${COL_GREEN}"
+	echo -e "Configuration will be stored for all users on this machine ('HKEY_LOCAL_MACHINE')"
+	echo -e "${COL_RESET}"
+fi
+
 TEMPLATE="${TEMPLATE_SHELL}_here.template"
 if [[ -f /start_shell.cmd ]]; then
     TEMPLATE="${TEMPLATE_SHELL}_here_start_shell.template"
@@ -101,14 +113,14 @@ if ( \
     MSYS2_INSTALL_DIR=$(echo $MSYS2_INSTALL_DIR | sed 's/\\/\\\\/g')
 
     cat reg.template | sed 's/$/\r/' > $REG_FILE
-    cat reg_mingw32.template | sed -e "s/{SCRIPT_HERE_PATH_WIN}/$MINGW32_HERE_PATH/g" | sed -e "s/{MSYS2_INSTALL_DIR}/$MSYS2_INSTALL_DIR/g" | sed 's/$/\r/' >> $REG_FILE 
-    cat reg_mingw64.template | sed -e "s/{SCRIPT_HERE_PATH_WIN}/$MINGW64_HERE_PATH/g" | sed -e "s/{MSYS2_INSTALL_DIR}/$MSYS2_INSTALL_DIR/g" | sed 's/$/\r/' >> $REG_FILE
-    cat reg_msys2.template | sed -e "s/{SCRIPT_HERE_PATH_WIN}/$MSYS2_HERE_PATH/g" | sed -e "s/{MSYS2_INSTALL_DIR}/$MSYS2_INSTALL_DIR/g" | sed 's/$/\r/' >> $REG_FILE
+    cat reg_mingw32.template | sed -e "s/{SCRIPT_HERE_PATH_WIN}/$MINGW32_HERE_PATH/g" | sed -e "s/{MSYS2_INSTALL_DIR}/$MSYS2_INSTALL_DIR/g" | sed -e "s/{ROOT_KEY}/$ROOT_KEY/g" | sed 's/$/\r/' >> $REG_FILE 
+    cat reg_mingw64.template | sed -e "s/{SCRIPT_HERE_PATH_WIN}/$MINGW64_HERE_PATH/g" | sed -e "s/{MSYS2_INSTALL_DIR}/$MSYS2_INSTALL_DIR/g" | sed -e "s/{ROOT_KEY}/$ROOT_KEY/g" | sed 's/$/\r/' >> $REG_FILE
+    cat reg_msys2.template | sed -e "s/{SCRIPT_HERE_PATH_WIN}/$MSYS2_HERE_PATH/g" | sed -e "s/{MSYS2_INSTALL_DIR}/$MSYS2_INSTALL_DIR/g" | sed -e "s/{ROOT_KEY}/$ROOT_KEY/g" | sed 's/$/\r/' >> $REG_FILE
 else
     echo "Using all-in-one reg file template"
     echo "You can delete this directory after merging the reg file"
     MSYS2_INSTALL_DIR=$(echo $MSYS2_INSTALL_DIR | sed 's/\\/\\\\/g')
-    cat reg_aio_${TEMPLATE_SHELL}_msys2_shell.template | sed -e "s/{MSYS2_INSTALL_DIR}/$MSYS2_INSTALL_DIR/g" | sed 's/$/\r/' > $REG_FILE 
+    cat reg_aio_${TEMPLATE_SHELL}_msys2_shell.template | sed -e "s/{MSYS2_INSTALL_DIR}/$MSYS2_INSTALL_DIR/g" | sed -e "s/{ROOT_KEY}/$ROOT_KEY/g" | sed 's/$/\r/' > $REG_FILE 
 
     FILESYSTEM_VERSION=$(pacman -Q filesystem | cut -d " " -f 2)
     echo "Filesystem version: ${FILESYSTEM_VERSION}"

--- a/install
+++ b/install
@@ -68,6 +68,7 @@ else
 	ROOT_KEY="HKEY_LOCAL_MACHINE"
 	echo -e "${COL_GREEN}"
 	echo -e "Configuration will be stored for all users on this machine ('HKEY_LOCAL_MACHINE')"
+	echo -e "If this is not working, run this script again appending --user for user context only"
 	echo -e "${COL_RESET}"
 fi
 

--- a/reg_aio_bash_msys2_shell.template
+++ b/reg_aio_bash_msys2_shell.template
@@ -1,23 +1,23 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\mingw32]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\mingw32]
 @="MinGW &32 Bash Here"
 "Icon"="\"{MSYS2_INSTALL_DIR}mingw32.exe\""
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\mingw32\command]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\mingw32\command]
 @="{MSYS2_INSTALL_DIR}msys2_shell.cmd -mingw32 -here \"%v\""
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\mingw64]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\mingw64]
 @="MinGW 64 Ba&sh Here"
 "Icon"="\"{MSYS2_INSTALL_DIR}mingw64.exe\""
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\mingw64\command]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\mingw64\command]
 @="{MSYS2_INSTALL_DIR}msys2_shell.cmd -mingw64 -here \"%v\""
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\msys2]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\msys2]
 @="MSYS2 Bash Here"
 "Icon"="\"{MSYS2_INSTALL_DIR}msys2.ico\""
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\msys2\command]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\msys2\command]
 @="{MSYS2_INSTALL_DIR}msys2_shell.cmd -msys -here \"%v\""
 

--- a/reg_aio_zsh_msys2_shell_example.template
+++ b/reg_aio_zsh_msys2_shell_example.template
@@ -1,23 +1,23 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\mingw32]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\mingw32]
 @="MinGW [&3]2 Zsh Here"
 "Icon"="\"{MSYS2_INSTALL_DIR}mingw32.exe\""
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\mingw32\command]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\mingw32\command]
 @="{MSYS2_INSTALL_DIR}msys2_shell_zsh.cmd -mingw32 -here \"%v\""
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\mingw64]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\mingw64]
 @="MinGW 64 Z[&s]h Here"
 "Icon"="\"{MSYS2_INSTALL_DIR}mingw64.exe\""
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\mingw64\command]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\mingw64\command]
 @="{MSYS2_INSTALL_DIR}msys2_shell_zsh.cmd -mingw64 -here \"%v\""
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\msys2]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\msys2]
 @="[&M]SYS2 Zsh Here"
 "Icon"="\"{MSYS2_INSTALL_DIR}msys2.ico\""
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\msys2\command]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\msys2\command]
 @="{MSYS2_INSTALL_DIR}msys2_shell_zsh.cmd -msys -here \"%v\""
 

--- a/reg_mingw32.template
+++ b/reg_mingw32.template
@@ -1,7 +1,7 @@
-[HKEY_CLASSES_ROOT\Directory\Background\shell\mingw32]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\mingw32]
 @="MinGW &32 Bash Here"
 "Icon"="\"{MSYS2_INSTALL_DIR}mingw32.exe\""
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\mingw32\command]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\mingw32\command]
 @="cmd /U /C \"{SCRIPT_HERE_PATH_WIN} \"%v\"\""
 

--- a/reg_mingw64.template
+++ b/reg_mingw64.template
@@ -1,7 +1,7 @@
-[HKEY_CLASSES_ROOT\Directory\Background\shell\mingw64]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\mingw64]
 @="MinGW 64 Ba&sh Here"
 "Icon"="\"{MSYS2_INSTALL_DIR}mingw64.exe\""
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\mingw64\command]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\mingw64\command]
 @="cmd /U /C \"{SCRIPT_HERE_PATH_WIN} \"%v\"\""
 

--- a/reg_msys2.template
+++ b/reg_msys2.template
@@ -1,7 +1,7 @@
-[HKEY_CLASSES_ROOT\Directory\Background\shell\msys2]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\msys2]
 @="MSYS2 Bash Here"
 "Icon"="\"{MSYS2_INSTALL_DIR}msys2.ico\""
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\msys2\command]
+[{ROOT_KEY}\Software\Classes\Directory\Background\shell\msys2\command]
 @="cmd /U /C \"{SCRIPT_HERE_PATH_WIN} \"%v\"\""
 


### PR DESCRIPTION
I've added the option '--user' to output a registry file which applies the changes in the context of the local user only. As 'HKEY_CLASSES_ROOT' is just a combination of 'HKEY_LOCAL_MACHINE\Software\Classes' and 'HKEY_CURRENT_USER\Software\Classes' the user is able to decide to have the menu entries for all users on the machine or just the current user. This is especially helpful in a company environment where write access to 'HKEY_CLASSES_ROOT' and 'HKEY_LOCAL_MACHINE' is usually prohibited.